### PR TITLE
Fix generation when vocabulary is small relative to beam size (fixes #7)

### DIFF
--- a/fairseq/modules/__init__.py
+++ b/fairseq/modules/__init__.py
@@ -6,9 +6,9 @@
 # can be found in the PATENTS file in the same directory.
 #
 
-from .beamable_mm import *
-from .linearized_convolution import *
+from .beamable_mm import BeamableMM
 from .conv_tbc import ConvTBC
+from .linearized_convolution import LinearizedConvolution
 
 __all__ = [
     'BeamableMM', 'LinearizedConvolution', 'ConvTBC',

--- a/fairseq/modules/beamable_mm.py
+++ b/fairseq/modules/beamable_mm.py
@@ -18,16 +18,16 @@ class BeamableMM(nn.Module):
     inference by replacing the inputs {(bsz x 1 x nhu), (bsz x sz2 x nhu)}
     with smaller inputs {(bsz/beam x beam x nhu), (bsz/beam x sz2 x nhu)}.
     """
-    def __init__(self, beam_size):
+    def __init__(self):
         super(BeamableMM, self).__init__()
-        self.beam_size = beam_size
+        self.beam_size = None
 
     def forward(self, input1, input2):
         if (
-            not self.training and   # test mode
-            self.beam_size > 0 and  # beam size is set
-            input1.dim() == 3 and   # only support batched input
-            input1.size(1) == 1     # single time step update
+            not self.training and           # test mode
+            self.beam_size is not None and  # beam size is set
+            input1.dim() == 3 and           # only support batched input
+            input1.size(1) == 1             # single time step update
         ):
             bsz, beam = input1.size(0), self.beam_size
 
@@ -45,3 +45,6 @@ class BeamableMM(nn.Module):
             return output.view(bsz, 1, -1)
         else:
             return input1.bmm(input2)
+
+    def set_beam_size(self, beam_size):
+        self.beam_size = beam_size

--- a/generate.py
+++ b/generate.py
@@ -47,7 +47,7 @@ def main():
 
     # Optimize model for generation
     for model in models:
-        model.make_generation_fast_(args.beam, not args.no_beamable_mm)
+        model.make_generation_fast_(not args.no_beamable_mm)
 
     # Initialize generator
     translator = SequenceGenerator(models, dataset.dst_dict, beam_size=args.beam,


### PR DESCRIPTION
Previously, generation would fail when the output vocabulary was small relative to the beam size. This PR fixes generation in this case by enforcing an upper bound on the beam size.