### PR TITLE
Adding a note about docker flags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ If you use the code in your paper, then please cite it as:
 Currently fairseq-py requires installing PyTorch from source.
 Please follow the instructions here: https://github.com/pytorch/pytorch#from-source.
 
+If you use Docker make sure to increase the shared memory size either with --ipc=host or --shm-size as command line options to `nvidia-docker run`.
+
 After PyTorch is installed, you can install fairseq-py with:
 ```
 pip install -r requirements.txt


### PR DESCRIPTION
The note is taken from https://github.com/pytorch/pytorch#from-source. If someone uses fairseq with docker and does not set these flags he will get a very obscurve `Bus error`.