### PR TITLE
Version 0.1.0 -> 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,14 +152,14 @@ $ python generate.py data-bin/wmt14.en-fr.newstest2014  \
   --path data-bin/wmt14.en-fr.fconv-py/model.pt \
   --beam 5 --batch-size 128 --remove-bpe | tee /tmp/gen.out
 ...
-| Translated 3003 sentences (95451 tokens) in 94.5s (1009.60 tokens/s)
-| Generate test with beam=5: BLEU4 = 40.70, 67.7/46.8/34.2/25.4 (BP=1.000, ratio=1.000, syslen=81190, reflen=81194)
+| Translated 3003 sentences (95451 tokens) in 93.8s (1018.09 tokens/s)
+| Generate test with beam=5: BLEU4 = 40.67, 67.7/46.7/34.2/25.3 (BP=1.000, ratio=0.998, syslen=81377, reflen=81194)
 
 # Scoring with score.py:
 $ grep ^H /tmp/gen.out | cut -f3- > /tmp/gen.out.sys
 $ grep ^T /tmp/gen.out | cut -f2- > /tmp/gen.out.ref
 $ python score.py --sys /tmp/gen.out.sys --ref /tmp/gen.out.ref
-BLEU4 = 40.70, 67.7/46.8/34.2/25.4 (BP=1.000, ratio=1.000, syslen=81190, reflen=81194)
+BLEU4 = 40.67, 67.7/46.7/34.2/25.3 (BP=1.000, ratio=0.998, syslen=81377, reflen=81194)
 ```
 
 # Join the fairseq community

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The following command-line tools are available:
 * `python preprocess.py`: Data pre-processing: build vocabularies and binarize training data
 * `python train.py`: Train a new model on one or multiple GPUs
 * `python generate.py`: Translate pre-processed data with a trained model
-* `python generate.py -i`: Translate raw text with a trained model
+* `python interactive.py`: Translate raw text with a trained model
 * `python score.py`: BLEU scoring of generated translations against reference translations
 
 ## Evaluating Pre-trained Models
@@ -57,22 +57,21 @@ This can be done with the [apply_bpe.py](https://github.com/rsennrich/subword-nm
 `@@` is used as a continuation marker and the original text can be easily recovered with e.g. `sed s/@@ //g` or by passing the `--remove-bpe` flag to `generate.py`.
 Prior to BPE, input text needs to be tokenized using `tokenizer.perl` from [mosesdecoder](https://github.com/moses-smt/mosesdecoder).
 
-Let's use `python generate.py -i` to generate translations.
+Let's use `python interactive.py` to generate translations interactively.
 Here, we use a beam size of 5:
 ```
 $ MODEL_DIR=wmt14.en-fr.fconv-py
-$ python generate.py -i \
+$ python interactive.py \
  --path $MODEL_DIR/model.pt $MODEL_DIR \
  --beam 5
+| loading model(s) from wmt14.en-fr.fconv-py/model.pt
 | [en] dictionary: 44206 types
 | [fr] dictionary: 44463 types
-| model fconv_wmt_en_fr
-| loaded checkpoint /private/home/edunov/wmt14.en-fr.fconv-py/model.pt (epoch 37)
+| Type the input sentence and press return:
 > Why is it rare to discover new marine mam@@ mal species ?
-S       Why is it rare to discover new marine mam@@ mal species ?
 O       Why is it rare to discover new marine mam@@ mal species ?
-H       -0.08662842959165573    Pourquoi est-il rare de découvrir de nouvelles espèces de mammifères marins ?
-A       0 1 3 3 5 6 6 10 8 8 8 11 12
+H       -0.06429661810398102    Pourquoi est-il rare de découvrir de nouvelles espèces de mammifères marins ?
+A       0 1 3 3 5 6 6 8 8 8 7 11 12
 ```
 
 This generation script produces four types of outputs: a line prefixed with *S* shows the supplied source sentence after applying the vocabulary; *O* is a copy of the original source sentence; *H* is the hypothesis along with an average log-likelihood; and *A* is the attention maxima for each word in the hypothesis, including the end-of-sentence marker which is omitted from the text.
@@ -114,7 +113,7 @@ Also note that the batch size is specified in terms of the maximum number of tok
 You may need to use a smaller value depending on the available GPU memory on your system.
 
 ### Generation
-Once your model is trained, you can generate translations using `python generate.py` **(for binarized data)** or `python generate.py -i` **(for raw text)**:
+Once your model is trained, you can generate translations using `python generate.py` **(for binarized data)** or `python interactive.py` **(for raw text)**:
 ```
 $ python generate.py data-bin/iwslt14.tokenized.de-en \
   --path checkpoints/fconv/checkpoint_best.pt \

--- a/fairseq/criterions/cross_entropy.py
+++ b/fairseq/criterions/cross_entropy.py
@@ -14,9 +14,8 @@ from .fairseq_criterion import FairseqCriterion
 
 class CrossEntropyCriterion(FairseqCriterion):
 
-    def __init__(self, padding_idx):
-        super().__init__()
-        self.padding_idx = padding_idx
+    def __init__(self, args, dst_dict):
+        super().__init__(args, dst_dict)
 
     def forward(self, model, sample):
         """Compute the loss for the given sample.
@@ -30,7 +29,7 @@ class CrossEntropyCriterion(FairseqCriterion):
         input = net_output.view(-1, net_output.size(-1))
         target = sample['target'].view(-1)
         loss = F.cross_entropy(input, target, size_average=False, ignore_index=self.padding_idx)
-        sample_size = sample['ntokens']
+        sample_size = sample['target'].size(0) if self.args.sentence_avg else sample['ntokens']
         logging_output = {
             'loss': loss.data[0],
             'sample_size': sample_size,

--- a/fairseq/criterions/fairseq_criterion.py
+++ b/fairseq/criterions/fairseq_criterion.py
@@ -11,8 +11,10 @@ from torch.nn.modules.loss import _Loss
 
 class FairseqCriterion(_Loss):
 
-    def __init__(self):
+    def __init__(self, args, dst_dict):
         super().__init__()
+        self.args = args
+        self.padding_idx = dst_dict.pad()
 
     def forward(self, model, sample):
         """Compute the loss for the given sample.

--- a/fairseq/criterions/label_smoothed_cross_entropy.py
+++ b/fairseq/criterions/label_smoothed_cross_entropy.py
@@ -14,7 +14,7 @@ import torch.nn.functional as F
 from .fairseq_criterion import FairseqCriterion
 
 
-class LabelSmoothedCrossEntropy(torch.autograd.Function):
+class LabelSmoothedNLLLoss(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, input, target, eps, padding_idx, weights):
@@ -59,7 +59,7 @@ class LabelSmoothedCrossEntropyCriterion(FairseqCriterion):
         net_output = model(**sample['net_input'])
         input = F.log_softmax(net_output.view(-1, net_output.size(-1)))
         target = sample['target'].view(-1)
-        loss = LabelSmoothedCrossEntropy.apply(input, target, self.eps, self.padding_idx, self.weights)
+        loss = LabelSmoothedNLLLoss.apply(input, target, self.eps, self.padding_idx, self.weights)
         sample_size = sample['target'].size(0) if self.args.sentence_avg else sample['ntokens']
         logging_output = {
             'loss': loss.data[0],

--- a/fairseq/criterions/label_smoothed_cross_entropy.py
+++ b/fairseq/criterions/label_smoothed_cross_entropy.py
@@ -43,10 +43,9 @@ class LabelSmoothedCrossEntropy(torch.autograd.Function):
 
 class LabelSmoothedCrossEntropyCriterion(FairseqCriterion):
 
-    def __init__(self, eps, padding_idx=None, weights=None):
-        super().__init__()
-        self.eps = eps
-        self.padding_idx = padding_idx
+    def __init__(self, args, dst_dict, weights=None):
+        super().__init__(args, dst_dict)
+        self.eps = args.label_smoothing
         self.weights = weights
 
     def forward(self, model, sample):
@@ -61,7 +60,7 @@ class LabelSmoothedCrossEntropyCriterion(FairseqCriterion):
         input = F.log_softmax(net_output.view(-1, net_output.size(-1)))
         target = sample['target'].view(-1)
         loss = LabelSmoothedCrossEntropy.apply(input, target, self.eps, self.padding_idx, self.weights)
-        sample_size = sample['ntokens']
+        sample_size = sample['target'].size(0) if self.args.sentence_avg else sample['ntokens']
         logging_output = {
             'loss': loss.data[0],
             'sample_size': sample_size,

--- a/fairseq/data.py
+++ b/fairseq/data.py
@@ -142,8 +142,8 @@ def skip_group_enumerator(it, ngpus, offset=0):
 class LanguagePairDataset(object):
 
     # padding constants
-    LEFT_PAD_SOURCE = False
-    LEFT_PAD_TARGET = True
+    LEFT_PAD_SOURCE = True
+    LEFT_PAD_TARGET = False
 
     def __init__(self, src, dst, pad_idx, eos_idx):
         self.src = src

--- a/fairseq/data.py
+++ b/fairseq/data.py
@@ -113,11 +113,9 @@ class LanguageDatasets(object):
             batch_sampler=batch_sampler)
 
     def eval_dataloader(self, split, num_workers=0, batch_size=1,
-                        max_tokens=None, consider_dst_sizes=True,
-                        max_positions=(1024, 1024),
+                        max_tokens=None, max_positions=(1024, 1024),
                         skip_invalid_size_inputs_valid_test=False):
         dataset = self.splits[split]
-        dst_dataset = dataset.dst if consider_dst_sizes else None
         batch_sampler = list(batches_by_size(
             dataset.src, dataset.dst, batch_size, max_tokens,
             max_positions=max_positions,

--- a/fairseq/dictionary.py
+++ b/fairseq/dictionary.py
@@ -45,7 +45,7 @@ class Dictionary(object):
         Can optionally remove BPE symbols or escape <unk> words.
         """
         if torch.is_tensor(tensor) and tensor.dim() == 2:
-            return '\n'.join(self.to_string(t) for t in tensor)
+            return '\n'.join(self.string(t) for t in tensor)
 
         def token_string(i):
             if i == self.unk():

--- a/fairseq/dictionary.py
+++ b/fairseq/dictionary.py
@@ -17,6 +17,7 @@ class Dictionary(object):
         self.symbols = []
         self.count = []
         self.indices = {}
+        # dictionary indexing starts at 1 for consistency with Lua
         self.add_symbol('<Lua heritage>')
         self.pad_index = self.add_symbol(pad)
         self.eos_index = self.add_symbol(eos)

--- a/fairseq/models/__init__.py
+++ b/fairseq/models/__init__.py
@@ -11,10 +11,10 @@ from .fairseq_encoder import FairseqEncoder
 from .fairseq_incremental_decoder import FairseqIncrementalDecoder
 from .fairseq_model import FairseqModel
 
-from . import fconv
+from . import fconv, lstm
 
 
-__all__ = ['fconv']
+__all__ = ['fconv', 'lstm']
 
 arch_model_map = {}
 for model in __all__:

--- a/fairseq/models/__init__.py
+++ b/fairseq/models/__init__.py
@@ -6,6 +6,11 @@
 # can be found in the PATENTS file in the same directory.
 #
 
+from .fairseq_decoder import FairseqDecoder
+from .fairseq_encoder import FairseqEncoder
+from .fairseq_incremental_decoder import FairseqIncrementalDecoder
+from .fairseq_model import FairseqModel
+
 from . import fconv
 
 

--- a/fairseq/models/fairseq_decoder.py
+++ b/fairseq/models/fairseq_decoder.py
@@ -6,10 +6,15 @@
 # can be found in the PATENTS file in the same directory.
 #
 
-from .cross_entropy import CrossEntropyCriterion
-from .label_smoothed_cross_entropy import LabelSmoothedCrossEntropyCriterion
+import torch.nn as nn
 
-__all__ = [
-    'CrossEntropyCriterion',
-    'LabelSmoothedCrossEntropyCriterion',
-]
+
+class FairseqDecoder(nn.Module):
+    """Base class for decoders."""
+
+    def __init__(self):
+        super().__init__()
+
+    def max_positions(self):
+        """Maximum input length supported by the decoder."""
+        raise NotImplementedError

--- a/fairseq/models/fairseq_encoder.py
+++ b/fairseq/models/fairseq_encoder.py
@@ -6,10 +6,15 @@
 # can be found in the PATENTS file in the same directory.
 #
 
-from .cross_entropy import CrossEntropyCriterion
-from .label_smoothed_cross_entropy import LabelSmoothedCrossEntropyCriterion
+import torch.nn as nn
 
-__all__ = [
-    'CrossEntropyCriterion',
-    'LabelSmoothedCrossEntropyCriterion',
-]
+
+class FairseqEncoder(nn.Module):
+    """Base class for encoders."""
+
+    def __init__(self):
+        super().__init__()
+
+    def max_positions(self):
+        """Maximum input length supported by the encoder."""
+        raise NotImplementedError

--- a/fairseq/models/fairseq_incremental_decoder.py
+++ b/fairseq/models/fairseq_incremental_decoder.py
@@ -18,12 +18,10 @@ class FairseqIncrementalDecoder(FairseqDecoder):
         self._incremental_state = {}
 
     def forward(self, tokens, encoder_out):
-        raise NotImplementedError
-
-    def incremental_forward(self, tokens, encoder_out):
-        """Forward pass for one time step."""
-        # keep only the last token for incremental forward pass
-        return self.forward(tokens[:, -1:], encoder_out)
+        if self._is_incremental_eval:
+            raise NotImplementedError
+        else:
+            raise NotImplementedError
 
     def incremental_inference(self):
         """Context manager for incremental inference.
@@ -38,8 +36,7 @@ class FairseqIncrementalDecoder(FairseqDecoder):
         ```
         with model.decoder.incremental_inference():
             for step in range(maxlen):
-                out, _ = model.decoder.incremental_forward(
-                    tokens[:, :step], encoder_out)
+                out, _ = model.decoder(tokens[:, :step], encoder_out)
                 probs = torch.nn.functional.log_softmax(out[:, -1, :])
         ```
         """

--- a/fairseq/models/fairseq_incremental_decoder.py
+++ b/fairseq/models/fairseq_incremental_decoder.py
@@ -6,8 +6,6 @@
 # can be found in the PATENTS file in the same directory.
 #
 
-import torch.nn as nn
-
 from . import FairseqDecoder
 
 

--- a/fairseq/models/fairseq_incremental_decoder.py
+++ b/fairseq/models/fairseq_incremental_decoder.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the LICENSE file in
+# the root directory of this source tree. An additional grant of patent rights
+# can be found in the PATENTS file in the same directory.
+#
+
+import torch.nn as nn
+
+from . import FairseqDecoder
+
+
+class FairseqIncrementalDecoder(FairseqDecoder):
+    """Base class for incremental decoders."""
+
+    def __init__(self):
+        super().__init__()
+        self._is_incremental_eval = False
+        self._incremental_state = {}
+
+    def forward(self, tokens, encoder_out):
+        raise NotImplementedError
+
+    def incremental_forward(self, tokens, encoder_out):
+        """Forward pass for one time step."""
+        # keep only the last token for incremental forward pass
+        return self.forward(tokens[:, -1:], encoder_out)
+
+    def incremental_inference(self):
+        """Context manager for incremental inference.
+
+        This provides an optimized forward pass for incremental inference
+        (i.e., it predicts one time step at a time). If the input order changes
+        between time steps, call reorder_incremental_state to update the
+        relevant buffers. To generate a fresh sequence, first call
+        clear_incremental_state.
+
+        Usage:
+        ```
+        with model.decoder.incremental_inference():
+            for step in range(maxlen):
+                out, _ = model.decoder.incremental_forward(
+                    tokens[:, :step], encoder_out)
+                probs = torch.nn.functional.log_softmax(out[:, -1, :])
+        ```
+        """
+        class IncrementalInference(object):
+            def __init__(self, decoder):
+                self.decoder = decoder
+
+            def __enter__(self):
+                self.decoder.incremental_eval(True)
+
+            def __exit__(self, *args):
+                self.decoder.incremental_eval(False)
+        return IncrementalInference(self)
+
+    def incremental_eval(self, mode=True):
+        """Sets the decoder and all children in incremental evaluation mode."""
+        assert self._is_incremental_eval != mode, \
+            'incremental_eval already set to mode {}'.format(mode)
+
+        self._is_incremental_eval = mode
+        if mode:
+            self.clear_incremental_state()
+
+        def apply_incremental_eval(module):
+            if module != self and hasattr(module, 'incremental_eval'):
+                module.incremental_eval(mode)
+        self.apply(apply_incremental_eval)
+
+    def get_incremental_state(self, key):
+        """Return cached state or None if not in incremental inference mode."""
+        if self._is_incremental_eval and key in self._incremental_state:
+            return self._incremental_state[key]
+        return None
+
+    def set_incremental_state(self, key, value):
+        """Cache state needed for incremental inference mode."""
+        if self._is_incremental_eval:
+            self._incremental_state[key] = value
+        return value
+
+    def clear_incremental_state(self):
+        """Clear all state used for incremental generation.
+
+        **For incremental inference only**
+
+        This should be called before generating a fresh sequence.
+        beam_size is required if using BeamableMM.
+        """
+        if self._is_incremental_eval:
+            self._incremental_state = {}
+
+            def apply_clear_incremental_state(module):
+                if module != self and hasattr(module, 'clear_incremental_state'):
+                    module.clear_incremental_state()
+            self.apply(apply_clear_incremental_state)
+
+    def reorder_incremental_state(self, new_order):
+        """Reorder buffered internal state (for incremental generation).
+
+        **For incremental inference only**
+
+        This should be called when the order of the input has changed from the
+        previous time step. A typical use case is beam search, where the input
+        order changes between time steps based on the choice of beams.
+        """
+        if self._is_incremental_eval:
+            def apply_reorder_incremental_state(module):
+                if module != self and hasattr(module, 'reorder_incremental_state'):
+                    module.reorder_incremental_state(new_order)
+            self.apply(apply_reorder_incremental_state)
+
+    def set_beam_size(self, beam_size):
+        """Sets the beam size in the decoder and all children."""
+        def apply_set_beam_size(module):
+            if module != self and hasattr(module, 'set_beam_size'):
+                module.set_beam_size(beam_size)
+        self.apply(apply_set_beam_size)

--- a/fairseq/models/fairseq_model.py
+++ b/fairseq/models/fairseq_model.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the LICENSE file in
+# the root directory of this source tree. An additional grant of patent rights
+# can be found in the PATENTS file in the same directory.
+#
+
+import torch.nn as nn
+
+from . import FairseqDecoder, FairseqEncoder
+
+
+class FairseqModel(nn.Module):
+    """Base class for encoder-decoder models."""
+
+    def __init__(self, encoder, decoder):
+        super().__init__()
+
+        self.encoder = encoder
+        self.decoder = decoder
+        assert isinstance(self.encoder, FairseqEncoder)
+        assert isinstance(self.decoder, FairseqDecoder)
+
+        self.src_dict = encoder.dictionary
+        self.dst_dict = decoder.dictionary
+        assert self.src_dict.pad() == self.dst_dict.pad()
+        assert self.src_dict.eos() == self.dst_dict.eos()
+        assert self.src_dict.unk() == self.dst_dict.unk()
+
+        self._is_generation_fast = False
+
+    def forward(self, src_tokens, input_tokens):
+        encoder_out = self.encoder(src_tokens)
+        decoder_out, _ = self.decoder(input_tokens, encoder_out)
+        return decoder_out.view(-1, decoder_out.size(-1))
+
+    def max_encoder_positions(self):
+        """Maximum input length supported by the encoder."""
+        return self.encoder.max_positions()
+
+    def max_decoder_positions(self):
+        """Maximum output length supported by the decoder."""
+        return self.decoder.max_positions()
+
+    def make_generation_fast_(self, **kwargs):
+        """Optimize model for faster generation."""
+        if self._is_generation_fast:
+            return  # only apply once
+        self._is_generation_fast = True
+
+        # remove weight norm from all modules in the network
+        def apply_remove_weight_norm(module):
+            try:
+                nn.utils.remove_weight_norm(module)
+            except ValueError:  # this module didn't have weight norm
+                return
+        self.apply(apply_remove_weight_norm)
+
+        def train(mode):
+            if mode:
+                raise RuntimeError('cannot train after make_generation_fast')
+
+        # this model should no longer be used for training
+        self.eval()
+        self.train = train
+
+        def apply_make_generation_fast_(module):
+            if module != self and hasattr(module, 'make_generation_fast_'):
+                module.make_generation_fast_(**kwargs)
+        self.apply(apply_make_generation_fast_)

--- a/fairseq/models/fconv.py
+++ b/fairseq/models/fconv.py
@@ -128,7 +128,7 @@ class AttentionLayer(nn.Module):
 
         # softmax over last dim
         sz = x.size()
-        x = F.softmax(x.view(sz[0] * sz[1], sz[2]))
+        x = F.softmax(x.view(sz[0] * sz[1], sz[2]), dim=1)
         x = x.view(sz)
         attn_scores = x
 

--- a/fairseq/models/fconv.py
+++ b/fairseq/models/fconv.py
@@ -185,6 +185,13 @@ class FConvDecoder(FairseqIncrementalDecoder):
         self.fc3 = Linear(out_embed_dim, num_embeddings, dropout=dropout)
 
     def forward(self, input_tokens, encoder_out):
+        if self._is_incremental_eval:
+            return self.incremental_forward(input_tokens, encoder_out)
+        else:
+            return self.batch_forward(input_tokens, encoder_out)
+
+    def batch_forward(self, input_tokens, encoder_out):
+        """Forward pass for decoding multiple time steps in batch mode."""
         positions = Variable(make_positions(input_tokens.data, self.dictionary.pad(),
                                             left_pad=LanguagePairDataset.LEFT_PAD_TARGET))
         return self._forward(input_tokens, positions, encoder_out)

--- a/fairseq/models/fconv.py
+++ b/fairseq/models/fconv.py
@@ -381,7 +381,7 @@ def build_model(args, src_dict, dst_dict):
         embed_dim=args.encoder_embed_dim,
         convolutions=eval(args.encoder_layers),
         dropout=args.dropout,
-        max_positions=args.max_positions,
+        max_positions=args.max_source_positions,
     )
     decoder = FConvDecoder(
         dst_dict,
@@ -390,6 +390,6 @@ def build_model(args, src_dict, dst_dict):
         out_embed_dim=args.decoder_out_embed_dim,
         attention=eval(args.decoder_attention),
         dropout=args.dropout,
-        max_positions=args.max_positions,
+        max_positions=args.max_target_positions,
     )
     return FConvModel(encoder, decoder)

--- a/fairseq/models/fconv.py
+++ b/fairseq/models/fconv.py
@@ -250,6 +250,10 @@ class FConvDecoder(FairseqIncrementalDecoder):
 
         return x, avg_attn_scores
 
+    def reorder_incremental_state(self, new_order):
+        """Reorder buffered internal state (for incremental generation)."""
+        super().reorder_incremental_state(new_order)
+
     def max_positions(self):
         """Maximum output length supported by the decoder."""
         return self.embed_positions.num_embeddings - self.dictionary.pad() - 1

--- a/fairseq/models/fconv.py
+++ b/fairseq/models/fconv.py
@@ -128,7 +128,7 @@ class AttentionLayer(nn.Module):
 
         # softmax over last dim
         sz = x.size()
-        x = F.softmax(x.view(sz[0] * sz[1], sz[2]), dim=1)
+        x = F.softmax(x.view(sz[0] * sz[1], sz[2]))
         x = x.view(sz)
         attn_scores = x
 

--- a/fairseq/models/lstm.py
+++ b/fairseq/models/lstm.py
@@ -1,0 +1,330 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the LICENSE file in
+# the root directory of this source tree. An additional grant of patent rights
+# can be found in the PATENTS file in the same directory.
+#
+
+import torch
+from torch.autograd import Variable
+import torch.nn as nn
+import torch.nn.functional as F
+
+from . import FairseqEncoder, FairseqIncrementalDecoder, FairseqModel
+
+
+class LSTMModel(FairseqModel):
+    def __init__(self, encoder, decoder):
+        super().__init__(encoder, decoder)
+
+
+class LSTMEncoder(FairseqEncoder):
+    """LSTM encoder."""
+    def __init__(self, dictionary, embed_dim=512, num_layers=1, dropout_in=0.1,
+                 dropout_out=0.1):
+        super().__init__()
+        self.dictionary = dictionary
+        self.dropout_in = dropout_in
+        self.dropout_out = dropout_out
+
+        num_embeddings = len(dictionary)
+        padding_idx = dictionary.pad()
+        self.embed_tokens = Embedding(num_embeddings, embed_dim, padding_idx)
+
+        self.layers = nn.ModuleList([
+            LSTMCell(embed_dim, embed_dim)
+            for layer in range(num_layers)
+        ])
+
+    def forward(self, src_tokens):
+        bsz, seqlen = src_tokens.size()
+        num_layers = len(self.layers)
+
+        # embed tokens
+        x = self.embed_tokens(src_tokens)
+        x = F.dropout(x, p=self.dropout_in, training=self.training)
+        embed_dim = x.size(2)
+
+        # B x T x C -> T x B x C
+        x = x.transpose(0, 1)
+
+        final_hiddens, final_cells = [], []
+        outs = [x[j] for j in range(seqlen)]
+        for i, rnn in enumerate(self.layers):
+            hidden = Variable(x.data.new(bsz, embed_dim).zero_())
+            cell = Variable(x.data.new(bsz, embed_dim).zero_())
+            for j in range(seqlen):
+                # recurrent cell
+                hidden, cell = rnn(outs[j], (hidden, cell))
+
+                # store the most recent hidden state in outs, either to be used
+                # as the input for the next layer, or as the final output
+                outs[j] = F.dropout(hidden, p=self.dropout_out, training=self.training)
+
+            # save the final hidden and cell states for every layer
+            final_hiddens.append(hidden)
+            final_cells.append(cell)
+
+        # collect outputs across time steps
+        x = torch.cat(outs, dim=0).view(seqlen, bsz, embed_dim)
+        final_hiddens = torch.cat(final_hiddens, dim=0).view(num_layers, bsz, embed_dim)
+        final_cells = torch.cat(final_cells, dim=0).view(num_layers, bsz, embed_dim)
+
+        return x, final_hiddens, final_cells
+
+    def max_positions(self):
+        """Maximum input length supported by the encoder."""
+        return int(1e5)  # an arbitrary large number
+
+
+class AttentionLayer(nn.Module):
+    def __init__(self, input_embed_dim, output_embed_dim):
+        super().__init__()
+
+        self.input_proj = Linear(input_embed_dim, output_embed_dim, bias=False)
+        self.output_proj = Linear(2*output_embed_dim, output_embed_dim, bias=False)
+
+    def forward(self, input, source_hids):
+        # input: bsz x input_embed_dim
+        # source_hids: srclen x bsz x output_embed_dim
+
+        # x: bsz x output_embed_dim
+        x = self.input_proj(input)
+
+        # compute attention
+        attn_scores = (source_hids * x.unsqueeze(0)).sum(dim=2)
+        attn_scores = F.softmax(attn_scores.t(), dim=1).t()  # srclen x bsz
+
+        # sum weighted sources
+        x = (attn_scores.unsqueeze(2) * source_hids).sum(dim=0)
+
+        x = F.tanh(self.output_proj(torch.cat((x, input), dim=1)))
+        return x, attn_scores
+
+
+class LSTMDecoder(FairseqIncrementalDecoder):
+    """LSTM decoder."""
+    def __init__(self, dictionary, encoder_embed_dim=512, embed_dim=512,
+                 out_embed_dim=512, num_layers=1, dropout_in=0.1,
+                 dropout_out=0.1, attention=True):
+        super().__init__()
+        self.dictionary = dictionary
+        self.dropout_in = dropout_in
+        self.dropout_out = dropout_out
+
+        num_embeddings = len(dictionary)
+        padding_idx = dictionary.pad()
+        self.embed_tokens = Embedding(num_embeddings, embed_dim, padding_idx)
+
+        self.layers = nn.ModuleList([
+            LSTMCell(encoder_embed_dim + embed_dim if layer == 0 else embed_dim, embed_dim)
+            for layer in range(num_layers)
+        ])
+        self.attention = AttentionLayer(encoder_embed_dim, embed_dim)
+        self.fc_out = Linear(out_embed_dim, num_embeddings, dropout=dropout_out)
+
+    def forward(self, input_tokens, encoder_out):
+        bsz, seqlen = input_tokens.size()
+        num_layers = len(self.layers)
+
+        # get outputs from encoder
+        encoder_outs, _, _ = encoder_out
+        srclen = encoder_outs.size(0)
+
+        # embed tokens
+        x = self.embed_tokens(input_tokens)
+        x = F.dropout(x, p=self.dropout_in, training=self.training)
+        embed_dim = x.size(2)
+
+        # B x T x C -> T x B x C
+        x = x.transpose(0, 1)
+
+        # initialize previous states (or get from cache during incremental generation)
+        prev_hiddens = self.get_incremental_state('prev_hiddens')
+        if not prev_hiddens:
+            # first time step, initialize previous states
+            prev_hiddens, prev_cells = self._init_prev_states(input_tokens, encoder_out)
+            input_feed = Variable(x.data.new(bsz, embed_dim).zero_())
+        else:
+            # previous states are cached
+            prev_cells = self.get_incremental_state('prev_cells')
+            input_feed = self.get_incremental_state('input_feed')
+
+        attn_scores = Variable(x.data.new(srclen, seqlen, bsz).zero_())
+        outs = []
+        for j in range(seqlen):
+            # input feeding: concatenate context vector from previous time step
+            input = torch.cat((x[j, :, :], input_feed), dim=1)
+
+            for i, rnn in enumerate(self.layers):
+                # recurrent cell
+                hidden, cell = rnn(input, (prev_hiddens[i], prev_cells[i]))
+
+                # hidden state becomes the input to the next layer
+                input = F.dropout(hidden, p=self.dropout_out, training=self.training)
+
+                # save state for next time step
+                prev_hiddens[i] = hidden
+                prev_cells[i] = cell
+
+            # apply attention using the last layer's hidden state
+            out, attn_scores[:, j, :] = self.attention(hidden, encoder_outs)
+            out = F.dropout(out, p=self.dropout_out, training=self.training)
+
+            # input feeding
+            input_feed = out
+
+            # save final output
+            outs.append(out)
+
+        # cache previous states (no-op except during incremental generation)
+        self.set_incremental_state('prev_hiddens', prev_hiddens)
+        self.set_incremental_state('prev_cells', prev_cells)
+        self.set_incremental_state('input_feed', input_feed)
+
+        # collect outputs across time steps
+        x = torch.cat(outs, dim=0).view(seqlen, bsz, embed_dim)
+
+        # T x B x C -> B x T x C
+        x = x.transpose(1, 0)
+
+        # srclen x tgtlen x bsz -> bsz x tgtlen x srclen
+        attn_scores = attn_scores.transpose(0, 2)
+
+        # project back to size of vocabulary
+        x = self.fc_out(x)
+
+        return x, attn_scores
+
+    def reorder_incremental_state(self, new_order):
+        """Reorder buffered internal state (for incremental generation)."""
+        super().reorder_incremental_state(new_order)
+        new_order = Variable(new_order)
+
+        def reorder_state(key):
+            old = self.get_incremental_state(key)
+            if isinstance(old, list):
+                new = [old_i.index_select(0, new_order) for old_i in old]
+            else:
+                new = old.index_select(0, new_order)
+            self.set_incremental_state(key, new)
+
+        reorder_state('prev_hiddens')
+        reorder_state('prev_cells')
+        reorder_state('input_feed')
+
+    def max_positions(self):
+        """Maximum output length supported by the decoder."""
+        return int(1e5)  # an arbitrary large number
+
+    def _init_prev_states(self, input_tokens, encoder_out):
+        _, encoder_hiddens, encoder_cells = encoder_out
+        bsz = input_tokens.size(0)
+        num_layers = len(self.layers)
+        embed_dim = encoder_hiddens.size(2)
+
+        prev_hiddens = [encoder_hiddens[i] for i in range(num_layers)]
+        prev_cells = [encoder_cells[i] for i in range(num_layers)]
+        return prev_hiddens, prev_cells
+
+
+def Embedding(num_embeddings, embedding_dim, padding_idx):
+    m = nn.Embedding(num_embeddings, embedding_dim, padding_idx=padding_idx)
+    m.weight.data.uniform_(-0.1, 0.1)
+    return m
+
+
+def LSTMCell(input_dim, hidden_dim, **kwargs):
+    m = nn.LSTMCell(input_dim, hidden_dim, **kwargs)
+    for name, param in m.named_parameters():
+        if 'weight' in name or 'bias' in name:
+            param.data.uniform_(-0.1, 0.1)
+    return m
+
+
+def Linear(in_features, out_features, bias=True, dropout=0):
+    """Weight-normalized Linear layer (input: N x T x C)"""
+    m = nn.Linear(in_features, out_features, bias=bias)
+    m.weight.data.uniform_(-0.1, 0.1)
+    if bias:
+        m.bias.data.uniform_(-0.1, 0.1)
+    return m
+
+
+def get_archs():
+    return [
+        'lstm', 'lstm_wiseman_iwslt_de_en', 'lstm_luong_wmt_en_de',
+    ]
+
+
+def _check_arch(args):
+    """Check that the specified architecture is valid and not ambiguous."""
+    if args.arch not in get_archs():
+        raise ValueError('Unknown LSTM model architecture: {}'.format(args.arch))
+    if args.arch != 'lstm':
+        # check that architecture is not ambiguous
+        for a in ['encoder_embed_dim', 'encoder_layers', 'decoder_embed_dim', 'decoder_layers',
+                  'decoder_out_embed_dim']:
+            if hasattr(args, a):
+                raise ValueError('--{} cannot be combined with --arch={}'.format(a, args.arch))
+
+
+def parse_arch(args):
+    _check_arch(args)
+
+    if args.arch == 'lstm_wiseman_iwslt_de_en':
+        args.encoder_embed_dim = 256
+        args.encoder_layers = 1
+        args.encoder_dropout_in = 0
+        args.encoder_dropout_out = 0
+        args.decoder_embed_dim = 256
+        args.decoder_layers = 1
+        args.decoder_out_embed_dim = 256
+        args.decoder_attention = True
+        args.decoder_dropout_in = 0
+    elif args.arch == 'lstm_luong_wmt_en_de':
+        args.encoder_embed_dim = 1000
+        args.encoder_layers = 4
+        args.encoder_dropout_out = 0
+        args.decoder_embed_dim = 1000
+        args.decoder_layers = 4
+        args.decoder_out_embed_dim = 1000
+        args.decoder_attention = True
+        args.decoder_dropout_out = 0
+    else:
+        assert args.arch == 'lstm'
+
+    # default architecture
+    args.encoder_embed_dim = getattr(args, 'encoder_embed_dim', 512)
+    args.encoder_layers = getattr(args, 'encoder_layers', 1)
+    args.encoder_dropout_in = getattr(args, 'encoder_dropout_in', args.dropout)
+    args.encoder_dropout_out = getattr(args, 'encoder_dropout_out', args.dropout)
+    args.decoder_embed_dim = getattr(args, 'decoder_embed_dim', 512)
+    args.decoder_layers = getattr(args, 'decoder_layers', 1)
+    args.decoder_out_embed_dim = getattr(args, 'decoder_out_embed_dim', 512)
+    args.decoder_attention = getattr(args, 'decoder_attention', True)
+    args.decoder_dropout_in = getattr(args, 'decoder_dropout_in', args.dropout)
+    args.decoder_dropout_out = getattr(args, 'decoder_dropout_out', args.dropout)
+    return args
+
+
+def build_model(args, src_dict, dst_dict):
+    encoder = LSTMEncoder(
+        src_dict,
+        embed_dim=args.encoder_embed_dim,
+        num_layers=int(args.encoder_layers),
+        dropout_in=args.encoder_dropout_in,
+        dropout_out=args.encoder_dropout_out,
+    )
+    decoder = LSTMDecoder(
+        dst_dict,
+        encoder_embed_dim=args.encoder_embed_dim,
+        embed_dim=args.decoder_embed_dim,
+        out_embed_dim=args.decoder_out_embed_dim,
+        num_layers=int(args.decoder_layers),
+        attention=bool(args.decoder_attention),
+        dropout_in=args.decoder_dropout_in,
+        dropout_out=args.decoder_dropout_out,
+    )
+    return LSTMModel(encoder, decoder)

--- a/fairseq/modules/__init__.py
+++ b/fairseq/modules/__init__.py
@@ -8,8 +8,12 @@
 
 from .beamable_mm import BeamableMM
 from .conv_tbc import ConvTBC
+from .grad_multiply import GradMultiply
 from .linearized_convolution import LinearizedConvolution
 
 __all__ = [
-    'BeamableMM', 'LinearizedConvolution', 'ConvTBC',
+    'BeamableMM',
+    'ConvTBC',
+    'GradMultiply',
+    'LinearizedConvolution',
 ]

--- a/fairseq/modules/beamable_mm.py
+++ b/fairseq/modules/beamable_mm.py
@@ -18,9 +18,9 @@ class BeamableMM(nn.Module):
     inference by replacing the inputs {(bsz x 1 x nhu), (bsz x sz2 x nhu)}
     with smaller inputs {(bsz/beam x beam x nhu), (bsz/beam x sz2 x nhu)}.
     """
-    def __init__(self):
+    def __init__(self, beam_size=None):
         super(BeamableMM, self).__init__()
-        self.beam_size = None
+        self.beam_size = beam_size
 
     def forward(self, input1, input2):
         if (

--- a/fairseq/modules/grad_multiply.py
+++ b/fairseq/modules/grad_multiply.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the LICENSE file in
+# the root directory of this source tree. An additional grant of patent rights
+# can be found in the PATENTS file in the same directory.
+#
+
+import torch
+
+
+class GradMultiply(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, scale):
+        ctx.scale = scale
+        res = x.new(x)
+        ctx.mark_shared_storage((x, res))
+        return res
+
+    @staticmethod
+    def backward(ctx, grad):
+        return grad * ctx.scale, None

--- a/fairseq/modules/linearized_convolution.py
+++ b/fairseq/modules/linearized_convolution.py
@@ -50,13 +50,6 @@ class LinearizedConvolution(ConvTBC):
         call reorder_incremental_state. To apply to fresh inputs, call
         clear_incremental_state.
         """
-        if self.training or not self._is_incremental_eval:
-            raise RuntimeError('incremental_forward only supports incremental evaluation')
-
-        # run forward pre hooks (e.g., weight norm)
-        for hook in self._forward_pre_hooks.values():
-            hook(self, input)
-
         # reshape weight
         weight = self._get_linearized_weight()
         kw = self.kernel_size[0]

--- a/fairseq/multiprocessing_trainer.py
+++ b/fairseq/multiprocessing_trainer.py
@@ -104,8 +104,9 @@ class MultiprocessingTrainer(MultiprocessingEventLoop):
             lr_scheduler = LambdaLR(self.optimizer, anneal)
             lr_scheduler.best = None
         else:
-            # decay the LR by 0.1 every time the validation loss plateaus
-            lr_scheduler = ReduceLROnPlateau(self.optimizer, patience=0)
+            # decay the LR by a factor every time the validation loss plateaus
+            lr_scheduler = ReduceLROnPlateau(self.optimizer, patience=0,
+                                             factor=self.args.lrshrink)
         return lr_scheduler
 
     def get_model(self):

--- a/fairseq/options.py
+++ b/fairseq/options.py
@@ -67,6 +67,8 @@ def add_optimization_args(parser):
                        help='If bigger than 0, use that number of mini-batches for each epoch,'
                             ' where each sample is drawn randomly without replacement from the'
                             ' dataset')
+    group.add_argument('--curriculum', default=0, type=int, metavar='N',
+                       help='sort batches by source length for first N epochs')
     return group
 
 

--- a/fairseq/options.py
+++ b/fairseq/options.py
@@ -65,7 +65,7 @@ def add_optimization_args(parser):
                        help='weight decay')
     group.add_argument('--sample-without-replacement', default=0, type=int, metavar='N',
                        help='If bigger than 0, use that number of mini-batches for each epoch,'
-                            ' where each sample is drawn randomly with replacement from the'
+                            ' where each sample is drawn randomly without replacement from the'
                             ' dataset')
     return group
 

--- a/fairseq/options.py
+++ b/fairseq/options.py
@@ -112,6 +112,8 @@ def add_generation_args(parser):
                        help='don\'t use BeamableMM in attention layers')
     group.add_argument('--lenpen', default=1, type=float,
                        help='length penalty: <1.0 favors shorter, >1.0 favors longer sentences')
+    group.add_argument('--unkpen', default=0, type=float,
+                       help='unknown word penalty: <0 produces more unks, >0 produces fewer')
     group.add_argument('--unk-replace-dict', default='', type=str,
                        help='performs unk word replacement')
     group.add_argument('--quiet', action='store_true',

--- a/fairseq/options.py
+++ b/fairseq/options.py
@@ -71,6 +71,9 @@ def add_optimization_args(parser):
                             ' dataset')
     group.add_argument('--curriculum', default=0, type=int, metavar='N',
                        help='sort batches by source length for first N epochs')
+    group.add_argument('--sentence-avg', action='store_true',
+                       help='normalize gradients by the number of sentences in a batch'
+                            ' (default is to normalize by number of tokens)')
     return group
 
 

--- a/fairseq/options.py
+++ b/fairseq/options.py
@@ -116,8 +116,8 @@ def add_generation_args(parser):
                        help='length penalty: <1.0 favors shorter, >1.0 favors longer sentences')
     group.add_argument('--unkpen', default=0, type=float,
                        help='unknown word penalty: <0 produces more unks, >0 produces fewer')
-    group.add_argument('--unk-replace-dict', default='', type=str,
-                       help='performs unk word replacement')
+    group.add_argument('--replace-unk', nargs='?', const=True, default=None,
+                       help='perform unknown replacement (optionally with alignment dictionary)')
     group.add_argument('--quiet', action='store_true',
                        help='Only print final scores')
 

--- a/fairseq/options.py
+++ b/fairseq/options.py
@@ -18,6 +18,8 @@ def get_parser(desc):
     parser.add_argument('--no-progress-bar', action='store_true', help='disable progress bar')
     parser.add_argument('--log-interval', type=int, default=1000, metavar='N',
                         help='log progress every N updates (when progress bar is disabled)')
+    parser.add_argument('--log-format', default='tqdm', help='log format to use',
+                        choices=['json', 'none', 'simple', 'tqdm'])
     parser.add_argument('--seed', default=1, type=int, metavar='N',
                         help='pseudo random number generator seed')
     return parser

--- a/fairseq/options.py
+++ b/fairseq/options.py
@@ -33,8 +33,10 @@ def add_dataset_args(parser):
                        help='target language')
     group.add_argument('-j', '--workers', default=1, type=int, metavar='N',
                        help='number of data loading workers (default: 1)')
-    group.add_argument('--max-positions', default=1024, type=int, metavar='N',
-                       help='max number of tokens in the sequence')
+    group.add_argument('--max-source-positions', default=1024, type=int, metavar='N',
+                       help='max number of tokens in the source sequence')
+    group.add_argument('--max-target-positions', default=1024, type=int, metavar='N',
+                       help='max number of tokens in the target sequence')
     group.add_argument('--skip-invalid-size-inputs-valid-test', action='store_true',
                        help='Ignore too long or too short lines in valid and test set')
     return group

--- a/fairseq/options.py
+++ b/fairseq/options.py
@@ -156,6 +156,16 @@ def add_model_args(parser):
     group.add_argument('--decoder-attention', type=str, metavar='EXPR',
                        help='decoder attention [True, ...]')
 
+    # Granular dropout settings for models that support them (e.g., LSTM):
+    group.add_argument('--encoder-dropout-in', type=float, metavar='D',
+                       help='dropout probability for encoder input embedding')
+    group.add_argument('--encoder-dropout-out', type=float, metavar='D',
+                       help='dropout probability for encoder output')
+    group.add_argument('--decoder-dropout-in', type=float, metavar='D',
+                       help='dropout probability for decoder input embedding')
+    group.add_argument('--decoder-dropout-out', type=float, metavar='D',
+                       help='dropout probability for decoder output')
+
     # These arguments have default values independent of the model:
     group.add_argument('--dropout', default=0.1, type=float, metavar='D',
                        help='dropout probability')

--- a/fairseq/progress_bar.py
+++ b/fairseq/progress_bar.py
@@ -80,7 +80,7 @@ class json_progress_bar(progress_bar):
     def __init__(self, iterable, epoch=None, prefix=None, log_interval=1000):
         super().__init__(iterable, epoch, prefix)
         self.log_interval = log_interval
-        self.postfix_json = None
+        self.stats = None
 
     def __iter__(self):
         size = float(len(self.iterable))

--- a/fairseq/sequence_generator.py
+++ b/fairseq/sequence_generator.py
@@ -330,7 +330,7 @@ class SequenceGenerator(object):
                 decoder_out, attn = model.decoder.incremental_forward(tokens, encoder_out)
             else:
                 decoder_out, attn = model.decoder.forward(tokens, encoder_out)
-            probs = F.softmax(decoder_out[:, -1, :], dim=1).data
+            probs = F.softmax(decoder_out[:, -1, :]).data
             attn = attn[:, -1, :].data
             if avg_probs is None or avg_attn is None:
                 avg_probs = probs

--- a/fairseq/sequence_generator.py
+++ b/fairseq/sequence_generator.py
@@ -61,10 +61,6 @@ class SequenceGenerator(object):
             cuda_device: GPU on which to do generation.
             timer: StopwatchMeter for timing generations.
         """
-
-        def lstrip_pad(tensor):
-            return tensor[tensor.eq(self.pad).sum():]
-
         if maxlen_b is None:
             maxlen_b = self.maxlen
 
@@ -80,8 +76,8 @@ class SequenceGenerator(object):
                 timer.stop(s['ntokens'])
             for i, id in enumerate(s['id']):
                 src = input['src_tokens'].data[i, :]
-                # remove padding from ref, which appears at the beginning
-                ref = lstrip_pad(s['target'].data[i, :])
+                # remove padding from ref
+                ref = utils.rstrip_pad(s['target'].data[i, :], self.pad)
                 yield id, src, ref, hypos[i]
 
     def generate(self, src_tokens, beam_size=None, maxlen=None):

--- a/fairseq/sequence_generator.py
+++ b/fairseq/sequence_generator.py
@@ -325,10 +325,7 @@ class SequenceGenerator(object):
         avg_probs = None
         avg_attn = None
         for model, encoder_out in zip(self.models, encoder_outs):
-            if isinstance(model.decoder, FairseqIncrementalDecoder):
-                decoder_out, attn = model.decoder.incremental_forward(tokens, encoder_out)
-            else:
-                decoder_out, attn = model.decoder.forward(tokens, encoder_out)
+            decoder_out, attn = model.decoder(tokens, encoder_out)
             probs = F.softmax(decoder_out[:, -1, :]).data
             attn = attn[:, -1, :].data
             if avg_probs is None or avg_attn is None:

--- a/fairseq/sequence_generator.py
+++ b/fairseq/sequence_generator.py
@@ -40,7 +40,7 @@ class SequenceGenerator(object):
         self.vocab_size = len(models[0].dst_dict)
         self.beam_size = beam_size
         self.minlen = minlen
-        self.maxlen = min(maxlen, *[m.decoder.max_positions() for m in self.models])
+        self.maxlen = min(maxlen, *[m.max_decoder_positions() for m in self.models])
         self.stop_early = stop_early
         self.normalize_scores = normalize_scores
         self.len_penalty = len_penalty

--- a/fairseq/sequence_generator.py
+++ b/fairseq/sequence_generator.py
@@ -250,10 +250,11 @@ class SequenceGenerator(object):
             eos_mask = cand_indices.eq(self.eos)
             if step >= self.minlen:
                 eos_bbsz_idx = buffer('eos_bbsz_idx')
-                cand_bbsz_idx.masked_select(eos_mask, out=eos_bbsz_idx)
+                # only consider eos when it's among the top beam_size indices
+                cand_bbsz_idx[:, :beam_size].masked_select(eos_mask[:, :beam_size], out=eos_bbsz_idx)
                 if eos_bbsz_idx.numel() > 0:
                     eos_scores = buffer('eos_scores', type_of=scores)
-                    cand_scores.masked_select(eos_mask, out=eos_scores)
+                    cand_scores[:, :beam_size].masked_select(eos_mask[:, :beam_size], out=eos_scores)
                     num_remaining_sent -= finalize_hypos(step, eos_bbsz_idx, eos_scores)
 
             assert num_remaining_sent >= 0

--- a/fairseq/sequence_generator.py
+++ b/fairseq/sequence_generator.py
@@ -330,7 +330,7 @@ class SequenceGenerator(object):
                 decoder_out, attn = model.decoder.incremental_forward(tokens, encoder_out)
             else:
                 decoder_out, attn = model.decoder.forward(tokens, encoder_out)
-            probs = F.softmax(decoder_out[:, -1, :]).data
+            probs = F.softmax(decoder_out[:, -1, :], dim=1).data
             attn = attn[:, -1, :].data
             if avg_probs is None or avg_attn is None:
                 avg_probs = probs

--- a/fairseq/utils.py
+++ b/fairseq/utils.py
@@ -14,7 +14,7 @@ import traceback
 from torch.autograd import Variable
 from torch.serialization import default_restore_location
 
-from fairseq import criterions, data, models, tokenizer
+from fairseq import criterions, data, models, progress_bar, tokenizer
 
 
 def parse_args_and_arch(parser):
@@ -34,6 +34,18 @@ def build_criterion(args, src_dict, dst_dict):
         return criterions.LabelSmoothedCrossEntropyCriterion(args, dst_dict)
     else:
         return criterions.CrossEntropyCriterion(args, dst_dict)
+
+
+def build_progress_bar(args, iterator, epoch=None, prefix=None):
+    if args.log_format == 'json':
+        bar = progress_bar.json_progress_bar(iterator, epoch, prefix, args.log_interval)
+    elif args.log_format == 'none':
+        bar = progress_bar.noop_progress_bar(iterator, epoch, prefix)
+    elif args.log_format == 'tqdm':
+        bar = progress_bar.tqdm_progress_bar(iterator, epoch, prefix)
+    else:
+        bar = progress_bar.simple_progress_bar(iterator, epoch, prefix, args.log_interval)
+    return bar
 
 
 def torch_persistent_save(*args, **kwargs):

--- a/fairseq/utils.py
+++ b/fairseq/utils.py
@@ -30,11 +30,10 @@ def build_model(args, src_dict, dst_dict):
 
 
 def build_criterion(args, src_dict, dst_dict):
-    padding_idx = dst_dict.pad()
     if args.label_smoothing > 0:
-        return criterions.LabelSmoothedCrossEntropyCriterion(args.label_smoothing, padding_idx)
+        return criterions.LabelSmoothedCrossEntropyCriterion(args, dst_dict)
     else:
-        return criterions.CrossEntropyCriterion(padding_idx)
+        return criterions.CrossEntropyCriterion(args, dst_dict)
 
 
 def torch_persistent_save(*args, **kwargs):

--- a/fairseq/utils.py
+++ b/fairseq/utils.py
@@ -192,7 +192,8 @@ def load_align_dict(replace_unk):
 def replace_unk(hypo_str, src_str, alignment, align_dict, unk):
     # Tokens are strings here
     hypo_tokens = tokenizer.tokenize_line(hypo_str)
-    src_tokens = tokenizer.tokenize_line(src_str)
+    # TODO: Very rare cases where the replacement is '<eos>' should be handled gracefully
+    src_tokens = tokenizer.tokenize_line(src_str) + ['<eos>']
     for i, ht in enumerate(hypo_tokens):
         if ht == unk:
             src_token = src_tokens[alignment[i]]

--- a/fairseq/utils.py
+++ b/fairseq/utils.py
@@ -151,6 +151,6 @@ def prepare_sample(sample, volatile=False, cuda_device=None):
         'target': make_variable(sample['target']),
         'net_input': {
             key: make_variable(sample[key])
-            for key in ['src_tokens', 'src_positions', 'input_tokens', 'input_positions']
+            for key in ['src_tokens', 'input_tokens']
         },
     }

--- a/fairseq/utils.py
+++ b/fairseq/utils.py
@@ -127,6 +127,7 @@ def load_ensemble_for_inference(filenames, src_dict, dst_dict):
             torch.load(filename, map_location=lambda s, l: default_restore_location(s, 'cpu'))
         )
     args = states[0]['args']
+    args = _upgrade_args(args)
 
     # build ensemble
     ensemble = []
@@ -135,6 +136,13 @@ def load_ensemble_for_inference(filenames, src_dict, dst_dict):
         model.load_state_dict(state['model'])
         ensemble.append(model)
     return ensemble
+
+
+def _upgrade_args(args):
+    if not hasattr(args, 'max_source_positions'):
+        args.max_source_positions = args.max_positions
+        args.max_target_positions = args.max_positions
+    return args
 
 
 def prepare_sample(sample, volatile=False, cuda_device=None):

--- a/fairseq/utils.py
+++ b/fairseq/utils.py
@@ -202,3 +202,14 @@ def post_process_prediction(hypo_tokens, src_str, alignment, align_dict, dst_dic
         # Note that the dictionary can be modified inside the method.
         hypo_tokens = tokenizer.Tokenizer.tokenize(hypo_str, dst_dict, add_if_not_exist=True)
     return hypo_tokens, hypo_str, alignment
+
+
+def lstrip_pad(tensor, pad):
+    return tensor[tensor.eq(pad).sum():]
+
+
+def rstrip_pad(tensor, pad):
+    strip = tensor.eq(pad).sum()
+    if strip > 0:
+        return tensor[:-strip]
+    return tensor

--- a/generate.py
+++ b/generate.py
@@ -97,8 +97,8 @@ def main():
                     remove_bpe=args.remove_bpe)
 
                 if not args.quiet:
-                    print('A-{}\t{}'.format(sample_id, ' '.join(map(str, alignment))))
                     print('H-{}\t{}\t{}'.format(sample_id, hypo['score'], hypo_str))
+                    print('A-{}\t{}'.format(sample_id, ' '.join(map(str, alignment))))
 
                 # Score only the top hypothesis
                 if i == 0:

--- a/generate.py
+++ b/generate.py
@@ -34,7 +34,7 @@ def main():
     use_cuda = torch.cuda.is_available() and not args.cpu
 
     # Load dataset
-    dataset = data.load_with_check(args.data, [args.gen_subset], args.source_lang, args.target_lang)
+    dataset = data.load_dataset(args.data, [args.gen_subset], args.source_lang, args.target_lang)
     if args.source_lang is None or args.target_lang is None:
         # record inferred languages in args
         args.source_lang, args.target_lang = dataset.src, dataset.dst
@@ -67,9 +67,9 @@ def main():
     # Generate and compute BLEU score
     scorer = bleu.Scorer(dataset.dst_dict.pad(), dataset.dst_dict.eos(), dataset.dst_dict.unk())
     max_positions = min(model.max_encoder_positions() for model in models)
-    itr = dataset.dataloader(args.gen_subset, batch_size=args.batch_size,
-                             max_positions=max_positions,
-                             skip_invalid_size_inputs_valid_test=args.skip_invalid_size_inputs_valid_test)
+    itr = dataset.eval_dataloader(
+        args.gen_subset, batch_size=args.batch_size, max_positions=max_positions,
+        skip_invalid_size_inputs_valid_test=args.skip_invalid_size_inputs_valid_test)
     num_sentences = 0
     with progress_bar(itr, smoothing=0, leave=False) as t:
         wps_meter = TimeMeter()

--- a/generate.py
+++ b/generate.py
@@ -60,7 +60,8 @@ def main():
     # Initialize generator
     translator = SequenceGenerator(
         models, beam_size=args.beam, stop_early=(not args.no_early_stop),
-        normalize_scores=(not args.unnormalized), len_penalty=args.lenpen)
+        normalize_scores=(not args.unnormalized), len_penalty=args.lenpen,
+        unk_penalty=args.unkpen)
     if use_cuda:
         translator.cuda()
 

--- a/generate.py
+++ b/generate.py
@@ -7,9 +7,7 @@
 # can be found in the PATENTS file in the same directory.
 #
 
-import sys
 import torch
-from torch.autograd import Variable
 
 from fairseq import bleu, data, options, tokenizer, utils
 from fairseq.meters import StopwatchMeter, TimeMeter
@@ -22,8 +20,6 @@ def main():
     parser.add_argument('--path', metavar='FILE', required=True, action='append',
                         help='path(s) to model file(s)')
     dataset_args = options.add_dataset_args(parser)
-    dataset_args.add_argument('-i', '--interactive', action='store_true',
-                              help='generate translations in interactive mode')
     dataset_args.add_argument('--batch-size', default=32, type=int, metavar='N',
                               help='batch size')
     dataset_args.add_argument('--gen-subset', default='test', metavar='SPLIT',
@@ -49,8 +45,7 @@ def main():
 
     print('| [{}] dictionary: {} types'.format(dataset.src, len(dataset.src_dict)))
     print('| [{}] dictionary: {} types'.format(dataset.dst, len(dataset.dst_dict)))
-    if not args.interactive:
-        print('| {} {} {} examples'.format(args.data, args.gen_subset, len(dataset.splits[args.gen_subset])))
+    print('| {} {} {} examples'.format(args.data, args.gen_subset, len(dataset.splits[args.gen_subset])))
 
     # Optimize ensemble for generation
     for model in models:
@@ -66,90 +61,61 @@ def main():
         translator.cuda()
 
     # Load alignment dictionary for unknown word replacement
-    align_dict = {}
-    if args.unk_replace_dict != '':
-        assert args.interactive, \
-            'Unknown word replacement requires access to original source and is only supported in interactive mode'
-        with open(args.unk_replace_dict, 'r') as f:
-            for line in f:
-                l = line.split()
-                align_dict[l[0]] = l[1]
+    # (None if no unknown word replacement, empty if no path to align dictionary)
+    align_dict = utils.load_align_dict(args.replace_unk)
 
-    def replace_unk(hypo_str, align_str, src, unk):
-        hypo_tokens = hypo_str.split()
-        src_tokens = tokenizer.tokenize_line(src)
-        align_idx = [int(i) for i in align_str.split()]
-        for i, ht in enumerate(hypo_tokens):
-            if ht == unk:
-                src_token = src_tokens[align_idx[i]]
-                if src_token in align_dict:
-                    hypo_tokens[i] = align_dict[src_token]
-                else:
-                    hypo_tokens[i] = src_token
-        return ' '.join(hypo_tokens)
+    # Generate and compute BLEU score
+    scorer = bleu.Scorer(dataset.dst_dict.pad(), dataset.dst_dict.eos(), dataset.dst_dict.unk())
+    max_positions = min(model.max_encoder_positions() for model in models)
+    itr = dataset.dataloader(args.gen_subset, batch_size=args.batch_size,
+                             max_positions=max_positions,
+                             skip_invalid_size_inputs_valid_test=args.skip_invalid_size_inputs_valid_test)
+    num_sentences = 0
+    with progress_bar(itr, smoothing=0, leave=False) as t:
+        wps_meter = TimeMeter()
+        gen_timer = StopwatchMeter()
+        translations = translator.generate_batched_itr(
+            t, maxlen_a=args.max_len_a, maxlen_b=args.max_len_b,
+            cuda_device=0 if use_cuda else None, timer=gen_timer)
+        for sample_id, src_tokens, target_tokens, hypos in translations:
+            # Process input and ground truth
+            target_tokens = target_tokens.int().cpu()
+            src_str = dataset.src_dict.string(src_tokens, args.remove_bpe)
+            target_str = dataset.dst_dict.string(target_tokens, args.remove_bpe, escape_unk=True)
+            if not args.quiet:
+                print('S-{}\t{}'.format(sample_id, src_str))
+                print('T-{}\t{}'.format(sample_id, target_str))
 
-    def display_hypotheses(id, src, orig, ref, hypos):
-        if args.quiet:
-            return
-        id_str = '' if id is None else '-{}'.format(id)
-        src_str = dataset.src_dict.string(src, args.remove_bpe)
-        print('S{}\t{}'.format(id_str, src_str))
-        if orig is not None:
-            print('O{}\t{}'.format(id_str, orig.strip()))
-        if ref is not None:
-            print('T{}\t{}'.format(id_str, dataset.dst_dict.string(ref, args.remove_bpe, escape_unk=True)))
-        for hypo in hypos:
-            hypo_str = dataset.dst_dict.string(hypo['tokens'], args.remove_bpe)
-            align_str = ' '.join(map(str, hypo['alignment']))
-            if args.unk_replace_dict != '':
-                hypo_str = replace_unk(hypo_str, align_str, orig, dataset.dst_dict.unk_string())
-            print('H{}\t{}\t{}'.format(id_str, hypo['score'], hypo_str))
-            print('A{}\t{}'.format(id_str, align_str))
+            # Process top predictions
+            for i, hypo in enumerate(hypos[:min(len(hypos), args.nbest)]):
+                hypo_tokens, hypo_str, alignment = utils.post_process_prediction(
+                    hypo_tokens=hypo['tokens'].int().cpu(),
+                    src_str=src_str,
+                    alignment=hypo['alignment'].int().cpu(),
+                    align_dict=align_dict,
+                    dst_dict=dataset.dst_dict,
+                    remove_bpe=args.remove_bpe)
 
-    if args.interactive:
-        for line in sys.stdin:
-            tokens = tokenizer.Tokenizer.tokenize(line, dataset.src_dict, add_if_not_exist=False).long()
-            if use_cuda:
-                tokens = tokens.cuda()
-            translations = translator.generate(Variable(tokens.view(1, -1)))
-            hypos = translations[0]
-            display_hypotheses(None, tokens, line, None, hypos[:min(len(hypos), args.nbest)])
+                if not args.quiet:
+                    print('A-{}\t{}'.format(sample_id, ' '.join(map(str, alignment))))
+                    print('H-{}\t{}\t{}'.format(sample_id, hypo['score'], hypo_str))
 
-    else:
-        def maybe_remove_bpe(tokens, escape_unk=False):
-            """Helper for removing BPE symbols from a hypothesis."""
-            if args.remove_bpe is None:
-                return tokens
-            assert (tokens == dataset.dst_dict.pad()).sum() == 0
-            hypo_minus_bpe = dataset.dst_dict.string(tokens, args.remove_bpe, escape_unk)
-            return tokenizer.Tokenizer.tokenize(hypo_minus_bpe, dataset.dst_dict, add_if_not_exist=True)
+                # Score only the top hypothesis
+                if i == 0:
+                    if args.remove_bpe is not None:
+                        # Convert the string without BPE back to tokens for evaluation
+                        target_tokens = tokenizer.Tokenizer.tokenize(target_str,
+                                                                     dataset.dst_dict,
+                                                                     add_if_not_exist=True)
+                    scorer.add(target_tokens, hypo_tokens)
 
-        # Generate and compute BLEU score
-        scorer = bleu.Scorer(dataset.dst_dict.pad(), dataset.dst_dict.eos(), dataset.dst_dict.unk())
-        max_positions = min(model.max_encoder_positions() for model in models)
-        itr = dataset.dataloader(args.gen_subset, batch_size=args.batch_size,
-                                 max_positions=max_positions,
-                                 skip_invalid_size_inputs_valid_test=args.skip_invalid_size_inputs_valid_test)
-        num_sentences = 0
-        with progress_bar(itr, smoothing=0, leave=False) as t:
-            wps_meter = TimeMeter()
-            gen_timer = StopwatchMeter()
-            translations = translator.generate_batched_itr(
-                t, maxlen_a=args.max_len_a, maxlen_b=args.max_len_b,
-                cuda_device=0 if use_cuda else None, timer=gen_timer)
-            for id, src, ref, hypos in translations:
-                ref = ref.int().cpu()
-                top_hypo = hypos[0]['tokens'].int().cpu()
-                scorer.add(maybe_remove_bpe(ref, escape_unk=True), maybe_remove_bpe(top_hypo))
-                display_hypotheses(id, src, None, ref, hypos[:min(len(hypos), args.nbest)])
+            wps_meter.update(src_tokens.size(0))
+            t.set_postfix(wps='{:5d}'.format(round(wps_meter.avg)), refresh=False)
+            num_sentences += 1
 
-                wps_meter.update(src.size(0))
-                t.set_postfix(wps='{:5d}'.format(round(wps_meter.avg)), refresh=False)
-                num_sentences += 1
-
-        print('| Translated {} sentences ({} tokens) in {:.1f}s ({:.2f} tokens/s)'.format(
-            num_sentences, gen_timer.n, gen_timer.sum, 1. / gen_timer.avg))
-        print('| Generate {} with beam={}: {}'.format(args.gen_subset, args.beam, scorer.result_string()))
+    print('| Translated {} sentences ({} tokens) in {:.1f}s ({:.2f} tokens/s)'.format(
+        num_sentences, gen_timer.n, gen_timer.sum, 1. / gen_timer.avg))
+    print('| Generate {} with beam={}: {}'.format(args.gen_subset, args.beam, scorer.result_string()))
 
 
 if __name__ == '__main__':

--- a/generate.py
+++ b/generate.py
@@ -41,7 +41,7 @@ def main():
 
     # Load ensemble
     print('| loading model(s) from {}'.format(', '.join(args.path)))
-    models = utils.load_ensemble_for_inference(args.path, dataset.src_dict, dataset.dst_dict)
+    models, _ = utils.load_ensemble_for_inference(args.path, dataset.src_dict, dataset.dst_dict)
 
     print('| [{}] dictionary: {} types'.format(dataset.src, len(dataset.src_dict)))
     print('| [{}] dictionary: {} types'.format(dataset.dst, len(dataset.dst_dict)))

--- a/generate.py
+++ b/generate.py
@@ -68,7 +68,7 @@ def main():
     scorer = bleu.Scorer(dataset.dst_dict.pad(), dataset.dst_dict.eos(), dataset.dst_dict.unk())
     max_positions = min(model.max_encoder_positions() for model in models)
     itr = dataset.eval_dataloader(
-        args.gen_subset, batch_size=args.batch_size, max_positions=max_positions,
+        args.gen_subset, max_sentences=args.batch_size, max_positions=max_positions,
         skip_invalid_size_inputs_valid_test=args.skip_invalid_size_inputs_valid_test)
     num_sentences = 0
     with progress_bar(itr, smoothing=0, leave=False) as t:

--- a/interactive.py
+++ b/interactive.py
@@ -51,7 +51,7 @@ def main():
     # (None if no unknown word replacement, empty if no path to align dictionary)
     align_dict = utils.load_align_dict(args.replace_unk)
 
-    print('Type the input sentence and press return:')
+    print('| Type the input sentence and press return:')
     for src_str in sys.stdin:
         src_str = src_str.strip()
         src_tokens = tokenizer.Tokenizer.tokenize(src_str, src_dict, add_if_not_exist=False).long()
@@ -70,8 +70,8 @@ def main():
                 align_dict=align_dict,
                 dst_dict=dst_dict,
                 remove_bpe=args.remove_bpe)
-            print('A\t{}'.format(' '.join(map(str, alignment))))
             print('H\t{}\t{}'.format(hypo['score'], hypo_str))
+            print('A\t{}'.format(' '.join(map(str, alignment))))
 
 
 if __name__ == '__main__':

--- a/interactive.py
+++ b/interactive.py
@@ -10,7 +10,7 @@ import sys
 import torch
 from torch.autograd import Variable
 
-from fairseq import data, options, tokenizer, utils
+from fairseq import options, tokenizer, utils
 from fairseq.sequence_generator import SequenceGenerator
 
 
@@ -72,6 +72,7 @@ def main():
                 remove_bpe=args.remove_bpe)
             print('A\t{}'.format(' '.join(map(str, alignment))))
             print('H\t{}\t{}'.format(hypo['score'], hypo_str))
+
 
 if __name__ == '__main__':
     main()

--- a/interactive.py
+++ b/interactive.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the LICENSE file in
+# the root directory of this source tree. An additional grant of patent rights
+# can be found in the PATENTS file in the same directory.
+#
+import sys
+import torch
+from torch.autograd import Variable
+
+from fairseq import data, options, tokenizer, utils
+from fairseq.sequence_generator import SequenceGenerator
+
+
+def main():
+    parser = options.get_parser('Generation')
+    parser.add_argument('--path', metavar='FILE', required=True, action='append',
+                        help='path(s) to model file(s)')
+    options.add_dataset_args(parser)
+    options.add_generation_args(parser)
+
+    args = parser.parse_args()
+    print(args)
+
+    use_cuda = torch.cuda.is_available() and not args.cpu
+
+    # Load dataset
+    # TODO: load only dictionaries
+    dataset = data.load_with_check(args.data, ['test'], args.source_lang, args.target_lang)
+    if args.source_lang is None or args.target_lang is None:
+        # record inferred languages in args
+        args.source_lang, args.target_lang = dataset.src, dataset.dst
+
+    # Load ensemble
+    print('| loading model(s) from {}'.format(', '.join(args.path)))
+    models = utils.load_ensemble_for_inference(args.path, dataset.src_dict, dataset.dst_dict)
+
+    print('| [{}] dictionary: {} types'.format(dataset.src, len(dataset.src_dict)))
+    print('| [{}] dictionary: {} types'.format(dataset.dst, len(dataset.dst_dict)))
+
+    # Optimize ensemble for generation
+    for model in models:
+        model.make_generation_fast_(
+            beamable_mm_beam_size=None if args.no_beamable_mm else args.beam)
+
+    # Initialize generator
+    translator = SequenceGenerator(
+        models, beam_size=args.beam, stop_early=(not args.no_early_stop),
+        normalize_scores=(not args.unnormalized), len_penalty=args.lenpen,
+        unk_penalty=args.unkpen)
+    if use_cuda:
+        translator.cuda()
+
+    # Load alignment dictionary for unknown word replacement
+    # (None if no unknown word replacement, empty if no path to align dictionary)
+    align_dict = utils.load_align_dict(args.replace_unk)
+
+    print('Type the input sentence and press return:')
+    for src_str in sys.stdin:
+        src_str = src_str.strip()
+        src_tokens = tokenizer.Tokenizer.tokenize(src_str, dataset.src_dict, add_if_not_exist=False).long()
+        if use_cuda:
+            src_tokens = src_tokens.cuda()
+        translations = translator.generate(Variable(src_tokens.view(1, -1)))
+        hypos = translations[0]
+        print('O\t{}'.format(src_str))
+
+        # Process top predictions
+        for hypo in hypos[:min(len(hypos), args.nbest)]:
+            hypo_tokens, hypo_str, alignment = utils.post_process_prediction(
+                hypo_tokens=hypo['tokens'].int().cpu(),
+                src_str=src_str,
+                alignment=hypo['alignment'].int().cpu(),
+                align_dict=align_dict,
+                dst_dict=dataset.dst_dict,
+                remove_bpe=args.remove_bpe)
+            print('A\t{}'.format(' '.join(map(str, alignment))))
+            print('H\t{}\t{}'.format(hypo['score'], hypo_str))
+
+if __name__ == '__main__':
+    main()

--- a/interactive.py
+++ b/interactive.py
@@ -26,17 +26,13 @@ def main():
 
     use_cuda = torch.cuda.is_available() and not args.cpu
 
-    # Load dictionaries
-    if args.source_lang is None or args.target_lang is None:
-        args.source_lang, args.target_lang, _ = data.infer_language_pair(args.data, ['test'])
-    src_dict, dst_dict = data.load_dictionaries(args.data, args.source_lang, args.target_lang)
-
     # Load ensemble
     print('| loading model(s) from {}'.format(', '.join(args.path)))
-    models = utils.load_ensemble_for_inference(args.path, src_dict, dst_dict)
+    models, model_args = utils.load_ensemble_for_inference(args.path, data_dir=args.data)
+    src_dict, dst_dict = models[0].src_dict, models[0].dst_dict
 
-    print('| [{}] dictionary: {} types'.format(args.source_lang, len(src_dict)))
-    print('| [{}] dictionary: {} types'.format(args.target_lang, len(dst_dict)))
+    print('| [{}] dictionary: {} types'.format(model_args.source_lang, len(src_dict)))
+    print('| [{}] dictionary: {} types'.format(model_args.target_lang, len(dst_dict)))
 
     # Optimize ensemble for generation
     for model in models:

--- a/preprocess.py
+++ b/preprocess.py
@@ -8,8 +8,9 @@
 #
 
 import argparse
-import os
 from itertools import zip_longest
+import os
+import shutil
 
 from fairseq import dictionary, indexed_dataset
 from fairseq.tokenizer import Tokenizer
@@ -33,10 +34,11 @@ def main():
     parser.add_argument('--nwordstgt', metavar='N', default=-1, type=int, help='number of target words to retain')
     parser.add_argument('--nwordssrc', metavar='N', default=-1, type=int, help='number of source words to retain')
     parser.add_argument('--alignfile', metavar='ALIGN', default=None, help='an alignment file (optional)')
+    parser.add_argument('--output-format', metavar='FORMAT', default='binary', choices=['binary', 'raw'],
+                        help='output format (optional)')
 
     args = parser.parse_args()
     print(args)
-
     os.makedirs(args.destdir, exist_ok=True)
 
     if args.srcdict:
@@ -53,7 +55,7 @@ def main():
     tgt_dict.save(os.path.join(args.destdir, 'dict.{}.txt'.format(args.target_lang)),
                   threshold=args.thresholdtgt, nwords=args.nwordstgt)
 
-    def make_dataset(input_prefix, output_prefix, lang):
+    def make_binary_dataset(input_prefix, output_prefix, lang):
         dict = dictionary.Dictionary.load(os.path.join(args.destdir, 'dict.{}.txt'.format(lang)))
         print('| [{}] Dictionary: {} types'.format(lang, len(dict) - 1))
 
@@ -74,16 +76,24 @@ def main():
             args.destdir, output_prefix,
             args.source_lang, args.target_lang, lang))
 
-    make_dataset(args.trainpref, 'train', args.source_lang)
-    make_dataset(args.trainpref, 'train', args.target_lang)
+    def make_dataset(input_prefix, output_prefix, lang, output_format='binary'):
+        if output_format == 'binary':
+            make_binary_dataset(input_prefix, output_prefix, lang)
+        elif output_format == 'raw':
+            # Copy original text file to destination folder
+            output_text_file = os.path.join(args.destdir, f'{output_prefix}.{lang}')
+            shutil.copyfile('{}.{}'.format(input_prefix, lang), output_text_file)
+
+    make_dataset(args.trainpref, 'train', args.source_lang, args.output_format)
+    make_dataset(args.trainpref, 'train', args.target_lang, args.output_format)
     for k, validpref in enumerate(args.validpref.split(',')):
         outprefix = 'valid{}'.format(k) if k > 0 else 'valid'
-        make_dataset(validpref, outprefix, args.source_lang)
-        make_dataset(validpref, outprefix, args.target_lang)
+        make_dataset(validpref, outprefix, args.source_lang, args.output_format)
+        make_dataset(validpref, outprefix, args.target_lang, args.output_format)
     for k, testpref in enumerate(args.testpref.split(',')):
         outprefix = 'test{}'.format(k) if k > 0 else 'test'
-        make_dataset(testpref, outprefix, args.source_lang)
-        make_dataset(testpref, outprefix, args.target_lang)
+        make_dataset(testpref, outprefix, args.source_lang, args.output_format)
+        make_dataset(testpref, outprefix, args.target_lang, args.output_format)
     print('| Wrote preprocessed data to {}'.format(args.destdir))
 
     if args.alignfile:

--- a/preprocess.py
+++ b/preprocess.py
@@ -28,6 +28,8 @@ def main():
                         help='map words appearing less than threshold times to unknown')
     parser.add_argument('--thresholdsrc', metavar='N', default=0, type=int,
                         help='map words appearing less than threshold times to unknown')
+    parser.add_argument('--tgtdict', metavar='FP', help='reuse given target dictionary')
+    parser.add_argument('--srcdict', metavar='FP', help='reuse given source dictionary')
     parser.add_argument('--nwordstgt', metavar='N', default=-1, type=int, help='number of target words to retain')
     parser.add_argument('--nwordssrc', metavar='N', default=-1, type=int, help='number of source words to retain')
     parser.add_argument('--alignfile', metavar='ALIGN', default=None, help='an alignment file (optional)')
@@ -37,10 +39,17 @@ def main():
 
     os.makedirs(args.destdir, exist_ok=True)
 
-    src_dict = Tokenizer.build_dictionary(filename='{}.{}'.format(args.trainpref, args.source_lang))
+    if args.srcdict:
+        src_dict = dictionary.Dictionary.load(args.srcdict)
+    else:
+        src_dict = Tokenizer.build_dictionary(filename='{}.{}'.format(args.trainpref, args.source_lang))
     src_dict.save(os.path.join(args.destdir, 'dict.{}.txt'.format(args.source_lang)),
                   threshold=args.thresholdsrc, nwords=args.nwordssrc)
-    tgt_dict = Tokenizer.build_dictionary(filename='{}.{}'.format(args.trainpref, args.target_lang))
+
+    if args.tgtdict:
+        tgt_dict = dictionary.Dictionary.load(args.tgtdict)
+    else:
+        tgt_dict = Tokenizer.build_dictionary(filename='{}.{}'.format(args.trainpref, args.target_lang))
     tgt_dict.save(os.path.join(args.destdir, 'dict.{}.txt'.format(args.target_lang)),
                   threshold=args.thresholdtgt, nwords=args.nwordstgt)
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ class build_py_hook(build_py):
 
 setup(
     name='fairseq',
-    version='0.1.0',
+    version='0.2.0',
     description='Facebook AI Research Sequence-to-Sequence Toolkit',
     long_description=readme,
     license=license,

--- a/tests/test_convtbc.py
+++ b/tests/test_convtbc.py
@@ -10,7 +10,7 @@ import torch
 import unittest
 from fairseq.modules import ConvTBC
 import torch.nn as nn
-from torch.autograd import Variable, gradcheck
+from torch.autograd import Variable
 
 
 class TestConvTBC(unittest.TestCase):
@@ -31,7 +31,7 @@ class TestConvTBC(unittest.TestCase):
         output1d = conv1d(input1d)
 
         self.assertAlmostEqual(output_tbc.data.transpose(0, 1).transpose(1, 2), output1d.data)
-        
+
         grad_tbc = torch.randn(output_tbc.size())
         grad1d = grad_tbc.transpose(0, 1).transpose(1, 2).contiguous()
 

--- a/tests/test_label_smoothing.py
+++ b/tests/test_label_smoothing.py
@@ -8,7 +8,7 @@
 
 import torch
 import unittest
-from fairseq.criterions.label_smoothed_cross_entropy import LabelSmoothedCrossEntropy
+from fairseq.criterions.label_smoothed_cross_entropy import LabelSmoothedNLLLoss
 from torch.autograd import Variable, gradcheck
 
 
@@ -21,7 +21,7 @@ class TestLabelSmoothing(unittest.TestCase):
         input = Variable(torch.randn(3, 5), requires_grad=True)
         idx = torch.rand(3) * 4
         target = Variable(idx.long())
-        criterion = LabelSmoothedCrossEntropy()
+        criterion = LabelSmoothedNLLLoss()
         self.assertTrue(gradcheck(
             lambda x, y: criterion.apply(x, y, 0.1, 2, None), (input, target)
         ))

--- a/train.py
+++ b/train.py
@@ -125,12 +125,13 @@ def get_perplexity(loss):
 def train(args, epoch, batch_offset, trainer, dataset, max_positions, num_gpus):
     """Train the model for one epoch."""
 
-    torch.manual_seed(args.seed + epoch)
-    trainer.set_seed(args.seed + epoch)
+    seed = args.seed + epoch
+    torch.manual_seed(seed)
+    trainer.set_seed(seed)
 
     itr = dataset.dataloader(
         args.train_subset, num_workers=args.workers, max_tokens=args.max_tokens,
-        seed=args.seed, epoch=epoch, max_positions=max_positions,
+        seed=seed, epoch=epoch, max_positions=max_positions,
         sample_without_replacement=args.sample_without_replacement,
         skip_invalid_size_inputs_valid_test=args.skip_invalid_size_inputs_valid_test,
         sort_by_source_size=(epoch <= args.curriculum))

--- a/train.py
+++ b/train.py
@@ -74,7 +74,10 @@ def main():
     # The max number of positions can be different for train and valid
     # e.g., RNNs may support more positions at test time than seen in training
     max_positions_train = (args.max_source_positions, args.max_target_positions)
-    max_positions_valid = (model.max_encoder_positions(), model.max_decoder_positions())
+    max_positions_valid = (
+        min(args.max_source_positions, model.max_encoder_positions()),
+        min(args.max_target_positions, model.max_decoder_positions())
+    )
 
     # Start multiprocessing
     trainer = MultiprocessingTrainer(args, model, criterion)

--- a/train.py
+++ b/train.py
@@ -222,7 +222,9 @@ def validate(args, epoch, trainer, dataset, max_positions, subset, ngpus):
     itr = dataset.eval_dataloader(
         subset, max_tokens=args.max_tokens, max_sentences=args.max_sentences,
         max_positions=max_positions,
-        skip_invalid_size_inputs_valid_test=args.skip_invalid_size_inputs_valid_test)
+        skip_invalid_size_inputs_valid_test=args.skip_invalid_size_inputs_valid_test,
+        descending=True,  # largest batch first to warm the caching allocator
+    )
     loss_meter = AverageMeter()
     extra_meters = collections.defaultdict(lambda: AverageMeter())
 

--- a/train.py
+++ b/train.py
@@ -36,7 +36,7 @@ def main():
 
     args = utils.parse_args_and_arch(parser)
 
-    if args.no_progress_bar:
+    if args.no_progress_bar and args.log_format == 'tqdm':
         args.log_format = 'simple'
 
     if not os.path.exists(args.save_dir):

--- a/train.py
+++ b/train.py
@@ -46,7 +46,11 @@ def main():
     torch.manual_seed(args.seed)
 
     # Load dataset
-    dataset = data.load_dataset(args.data, ['train', 'valid'], args.source_lang, args.target_lang)
+    splits = ['train', 'valid']
+    if data.has_binary_files(args.data, splits):
+        dataset = data.load_dataset(args.data, splits, args.source_lang, args.target_lang)
+    else:
+        dataset = data.load_raw_text_dataset(args.data, splits, args.source_lang, args.target_lang)
     if args.source_lang is None or args.target_lang is None:
         # record inferred languages in args, so that it's saved in checkpoints
         args.source_lang, args.target_lang = dataset.src, dataset.dst
@@ -54,7 +58,7 @@ def main():
     print(args)
     print('| [{}] dictionary: {} types'.format(dataset.src, len(dataset.src_dict)))
     print('| [{}] dictionary: {} types'.format(dataset.dst, len(dataset.dst_dict)))
-    for split in ['train', 'valid']:
+    for split in splits:
         print('| {} {} {} examples'.format(args.data, split, len(dataset.splits[split])))
 
     if not torch.cuda.is_available():


### PR DESCRIPTION
Release notes:
- 5c7f495: Added simple LSTM model with input feeding and attention
- 6e4b7e2: Refactored model definitions and incremental generation to be cleaner
- 7ae79c1: Split interactive generation out of generate.py and into a new binary: interactive.py
- 19a3865: Subtle correctness fix in beam search decoder. Previously, for a beam size of k, we might emit a hypotheses if the <eos> was among the top 2*k candidates. Now we only emit hypotheses for which the <eos> is among the top-k candidates. This may subtly change generation results, and in the case of k=1 we will now produce strictly greedy outputs.
- 97d7fcb: Fixed bug in padding direction, where previously we right-padded the source and left-padded the target. We now left-pad the source and right-pad the target. This should not effect existing trained models, but may change (usually improves) the quality of new models.
- f442f89: Add support for batching based on the number of sentences (`--max-sentences`) in addition to the number of tokens (`--max-tokens`). When batching by the number of sentences, one can optionally normalize the gradients by the number of sentences with `--sentence-avg` (the default is to normalize by the number of tokens).
- c6d6256: Add `--log-format` option and JSON logger