### PR TITLE
fix typo in data/README

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -37,7 +37,7 @@ $ python generate.py data-bin/iwslt14.tokenized.de-en \
 
 Provides an example of pre-processing for the WMT'14 English to German translation task. By default it will produce a dataset that was modeled after ["Attention Is All You Need" by Vaswani et al.](https://arxiv.org/abs/1706.03762) that includes news-commentary-v12 data.
 
-To use only data awailable in WMT'14 or to replicate results obtained in the original paper ["Convolutional Sequence to Sequence Learning" by Gehring et al.](https://arxiv.org/abs/1705.03122) run it with --icml17 instead:
+To use only data available in WMT'14 or to replicate results obtained in the original paper ["Convolutional Sequence to Sequence Learning" by Gehring et al.](https://arxiv.org/abs/1705.03122) run it with --icml17 instead:
 
 ```
 $ bash prepare-wmt14en2de.sh --icml17


### PR DESCRIPTION
Change "awailable" to "available". It looks like a spelling error in the original version.